### PR TITLE
Updated ZDCChat/API subspec settings

### DIFF
--- a/ZDCChat.podspec
+++ b/ZDCChat.podspec
@@ -42,6 +42,5 @@ Pod::Spec.new do |s|
         ss.frameworks = 'SystemConfiguration'
         ss.ios.vendored_frameworks = 'ZDCChatAPI.framework'
         ss.preserve_paths = 'ZDCChatAPI.framework'
-        ss.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited)', 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES' }
     end
 end


### PR DESCRIPTION
Hi guys!

I started to use Zendesk for it's chat API and found out that because the API subspec's custom build settings my project should have turned the `CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES` flag to yes. Could you explain me why this is needed?

I looked at the public headers and none of them imports anything from outside of the framework and all of the imported headers are public too. I could not find the reason and the Zendesk chat API was still building / working after removing these from the podspec.