### PR TITLE
Fix ZDCAPIConfig import in category

### DIFF
--- a/ZDCChatAPI.framework/PrivateHeaders/ZDCAPIConfig+Timeout.h
+++ b/ZDCChatAPI.framework/PrivateHeaders/ZDCAPIConfig+Timeout.h
@@ -14,7 +14,7 @@
  *
  */
 
-#import "ZDCAPIConfig.h"
+#import <ZDCChatAPI/ZDCAPIConfig.h>
 
 
 @interface ZDCAPIConfig ()


### PR DESCRIPTION
Local header import ("ZDCAPIConfig.h") was causing build error:
"/Pods/ZDCChat/ZDCChatAPI.framework/PrivateHeaders/ZDCAPIConfig+Timeout.h:17:9: 'ZDCAPIConfig.h' file not found"

It's only logical as ZDCConfig+Timeout in ZDChat/ also uses system import (see /ZDCChat.framework/PrivateHeaders/ZDCConfig+Timeout.h)

SDK version 1.3.7.1
Xcode version 9.2
Using Cocoapods version 1.4.0 (pod => "ZDCChat")

![zdchatmissingheader](https://user-images.githubusercontent.com/37864243/38025826-76a2fd3a-3292-11e8-97d5-ee5766e1675b.png)
